### PR TITLE
menu metaComp argumentos

### DIFF
--- a/R/EcoVirtual.MetaMenu.R
+++ b/R/EcoVirtual.MetaMenu.R
@@ -1,6 +1,6 @@
 
 ########### Meta Menu #################
-intCol <-function () 
+intCol <-function ()
 {
 initializeDialog(title = gettextRcmdr("Internal Colonization"))
 #### Salva dados
@@ -19,31 +19,31 @@ fiVarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fiVar, resolu
 #####
 iVar <- tclVar("0.1") ## nclassVar ->iVar
 iEntry <- tkentry(top, width = "6", textvariable = iVar)
-peVar <- tclVar(0.05) 
+peVar <- tclVar(0.05)
 peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution=0.01, orient="horizontal")
-	onOK <- function() 
+	onOK <- function()
 	{
 	#closeDialog()
    tf <- round(as.numeric(tclvalue(tfVar)))
-        if (is.na(tf) || tf <= 0) 
+        if (is.na(tf) || tf <= 0)
         {
         errorCondition(message = "Number of simulations must be a positive integer")
         return()
         }
   	cl <- round(as.numeric(tclvalue(clVar)))
-        if (is.na(cl) || cl <= 0) 
+        if (is.na(cl) || cl <= 0)
         {
         errorCondition(message = "Number of columns on the simulated arena must be a positive integer.")
         return()
         }
 	ln <- round(as.numeric(tclvalue(lnVar)))
-        if (is.na(ln) || ln <= 0) 
+        if (is.na(ln) || ln <= 0)
         {
         errorCondition("Number of lines on the simulated arena must be a positive integer.")
         return()
         }
    i <- as.numeric(tclvalue(iVar))
-        if (i<0 || i > 10) 
+        if (i<0 || i > 10)
         {
         errorCondition(message = "Colonization constant must be between 0 and 10")
         return()
@@ -52,11 +52,11 @@ peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution
    pe <- as.numeric(tclvalue(peVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
-        if (dsnameValue == "Do_Not_Save" | dsnameValue=="") 
+        if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
         	command <- paste("metaCi(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
         }
-        else  
+        else
 		  {
 		  command <- paste(dsnameValue,"<- metaCi(tmax = ",tf, ", rw = ", cl,", fi = ", fi,", ln =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
 		  }
@@ -90,7 +90,7 @@ dialogSuffix(rows = 8, columns = 2, focus = tfEntry)
 
 ######################################
 ##########################################
-propRain <-function() 
+propRain <-function()
 {
 initializeDialog(title = gettextRcmdr("Propagulus Rain"))
 ####
@@ -109,23 +109,23 @@ pcVar <- tclVar("0.1") ## nclassVar ->fiVar
 pcEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=pcVar, resolution=0.01, orient="horizontal")
 peVar <- tclVar("0.05") ## nclassVar ->fiVar
 peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution=0.01, orient="horizontal")
-	onOK <- function() 
+	onOK <- function()
 	{
         #closeDialog()
         tf <- round(as.numeric(tclvalue(tfVar)))
-        if (is.na(tf) || tf <= 0) 
+        if (is.na(tf) || tf <= 0)
         {
             errorCondition(message = "Number of simulations must be a positive integer")
             return()
         }
         cl <- round(as.numeric(tclvalue(clVar)))
-        if (is.na(cl) || cl <= 0) 
+        if (is.na(cl) || cl <= 0)
         {
             errorCondition(message = "Number of columns on the simulated arena must be a positive integer.")
             return()
         }
         ln <- round(as.numeric(tclvalue(lnVar)))
-        if (is.na(ln) || ln <= 0) 
+        if (is.na(ln) || ln <= 0)
         {
             errorCondition("Number of lines on the simulated arena must be a positive integer.")
             return()
@@ -135,11 +135,11 @@ peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution
         pe <- as.numeric(tclvalue(peVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
-        if (dsnameValue == "Do_Not_Save" | dsnameValue=="") 
+        if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
         	command <- paste("metaPop(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", pe = ", pe, ")", sep = "")
         }
-        else  
+        else
 		  {
 		  command <- paste(dsnameValue,"<-metaPop(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", pe = ", pe, ")", sep = "")
 		  }
@@ -172,7 +172,7 @@ dialogSuffix(rows = 7, columns = 2, focus = tfEntry)
 ##################################################
 #metaCiEr <-function(tf,cl,ln,fi,i,e)
 #metaEr <-function(tf,cl,ln,fi,pc,e)
-resEff <-function () 
+resEff <-function ()
 {
 initializeDialog(title = gettextRcmdr("Rescue Effect"))
 ####
@@ -191,29 +191,29 @@ pcVar <- tclVar("0.1") ## nclassVar ->fiVar
 pcEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=pcVar, resolution=0.01, orient="horizontal")
 eVar <- tclVar("0.05") ## nclassVar ->fiVar
 eEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable = eVar, resolution=0.01, orient="horizontal")
-	onOK <- function() 
+	onOK <- function()
 	{
         #closeDialog()
         tf <- round(as.numeric(tclvalue(tfVar)))
-        if (is.na(tf) || tf <= 0) 
+        if (is.na(tf) || tf <= 0)
         {
             errorCondition(message = "Number of simulations must be a positive integer")
             return()
         }
         cl <- round(as.numeric(tclvalue(clVar)))
-        if (is.na(cl) || cl <= 0) 
+        if (is.na(cl) || cl <= 0)
         {
             errorCondition(message = "Number of columns on the simulated arena must be a positive integer.")
             return()
         }
         ln <- round(as.numeric(tclvalue(lnVar)))
-        if (is.na(ln) || ln <= 0) 
+        if (is.na(ln) || ln <= 0)
         {
             errorCondition("Number of lines on the simulated arena must be a positive integer.")
             return()
         }
         e <- as.numeric(tclvalue(eVar))
-        if (e<0 || e > 1) 
+        if (e<0 || e > 1)
         {
             errorCondition(message = "Extinction constant must be between 0 and 1")
             return()
@@ -222,15 +222,15 @@ eEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable = eVar, resolution
         pc <- as.numeric(tclvalue(pcVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
-        if (dsnameValue == "Do_Not_Save" | dsnameValue=="") 
+        if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
         	command <- paste("metaEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", ce = ", e, ")", sep = "")
         }
-        else  
+        else
 		  {
 		  command <- paste(dsnameValue,"<-metaEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", ce = ", e, ")", sep = "")
 		  }
-########   
+########
 #	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", fi = ", fi,", ln =", ln,", pc = ", pc,", e = ", e, ")", sep = "")
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
@@ -260,7 +260,7 @@ dialogSuffix(rows = 8, columns = 2, focus = tfEntry)
 #metaEr <-function(tf,cl,ln,fi,pc,e)
 
 
-resEffcol <-function () 
+resEffcol <-function ()
 {
 initializeDialog(title = gettextRcmdr("Rescue and Internal Colonization"))
 ####
@@ -279,35 +279,35 @@ iVar <- tclVar("0.1") ## nclassVar ->fiVar
 iEntry <- tkentry(top, width = "6", textvariable = iVar)
 eVar <- tclVar("0.05") ## nclassVar ->fiVar
 eEntry <- tkentry(top, width = "6", textvariable = eVar)
-	onOK <- function() 
+	onOK <- function()
 	{
         #closeDialog()
         tf <- round(as.numeric(tclvalue(tfVar)))
-        if (is.na(tf) || tf <= 0) 
+        if (is.na(tf) || tf <= 0)
         {
             errorCondition(message = "Number of simulations must be a positive integer")
             return()
         }
         cl <- round(as.numeric(tclvalue(clVar)))
-        if (is.na(cl) || cl <= 0) 
+        if (is.na(cl) || cl <= 0)
         {
             errorCondition(message = "Number of columns on the simulated arena must be a positive integer.")
             return()
         }
         ln <- round(as.numeric(tclvalue(lnVar)))
-        if (is.na(ln) || ln <= 0) 
+        if (is.na(ln) || ln <= 0)
         {
             errorCondition("Number of lines on the simulated arena must be a positive integer.")
             return()
         }
         e <- as.numeric(tclvalue(eVar))
-        if (e<0 || e > 100) 
+        if (e<0 || e > 100)
         {
             errorCondition(message = "Extinction constant must be positive ")
             return()
         }
         i <- as.numeric(tclvalue(iVar))
-        if (i<0 || i > 1000) 
+        if (i<0 || i > 1000)
         {
             errorCondition(message = "Extinction constant must be positive")
             return()
@@ -315,15 +315,15 @@ eEntry <- tkentry(top, width = "6", textvariable = eVar)
         fi <- as.numeric(tclvalue(fiVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
-        if (dsnameValue == "Do_Not_Save" | dsnameValue=="") 
+        if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
         	command <- paste("metaCiEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
         }
-        else  
+        else
 		  {
 		  command <- paste(dsnameValue,"<-metaCiEr(tmax = ",tf, ", rw = ", cl,", fi = ", fi,", ln =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
 		  }
-########   
+########
 #	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", fi = ", fi,", ln =", ln,", pc = ", pc,", e = ", e, ")", sep = "")
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
@@ -352,8 +352,8 @@ dialogSuffix(rows = 8, columns = 2, focus = tfEntry)
 
 ####################################
 ########################################################
-#metaComp(tmax=100,cl=100,ln=100,fi1=0.1,fi2=0.4,i1=0.4,i2=0.5,pe=0.25)
-metacompDb <-function () 
+#metaComp(tmax=100,cl=20,rw=20,f01=0.4,f02=0.4,i1=0.1,i2=0.1,pe=0.05, D=0,anima=TRUE)
+metacompDb <-function ()
 {
 initializeDialog(title = gettextRcmdr("Meta Competition"))
 #### Salva dados
@@ -363,78 +363,78 @@ entryDsname <- tkentry(top, width="20", textvariable=dsname)
 tmaxVar <- tclVar("100")
 tmaxEntry <- tkentry(top, width = "4", textvariable = tmaxVar)
 clVar <- tclVar("20")
-lnVar <- tclVar("20")
+rwVar <- tclVar("20")
 clEntry <- tkentry(top, width = "4", textvariable = clVar)
-lnEntry <- tkentry(top, width = "4", textvariable = lnVar)
+rwEntry <- tkentry(top, width = "4", textvariable = rwVar)
 ### controle de barra
 
-fi1Var <- tclVar(0.4)
-fi1VarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fi1Var, resolution=0.01, orient="horizontal")
-fi2Var <- tclVar(0.4)
-fi2VarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fi2Var, resolution=0.01, orient="horizontal")
+f01Var <- tclVar(0.4)
+f01VarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f01Var, resolution=0.01, orient="horizontal")
+f02Var <- tclVar(0.4)
+f02VarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f02Var, resolution=0.01, orient="horizontal")
 #####
 i1Var <- tclVar("0.1") ## nclassVar ->iVar
 i1Entry <- tkentry(top, width = "6", textvariable = i1Var)
 i2Var <- tclVar("0.1") ## nclassVar ->iVar
 i2Entry <- tkentry(top, width = "6", textvariable = i2Var)
-peVar <- tclVar(0.05) 
+peVar <- tclVar(0.05)
 peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution=0.01, orient="horizontal")
-distrVar <- tclVar(0.00) 
+distrVar <- tclVar(0.00)
 distrEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=distrVar, resolution=0.01, orient="horizontal")
 cantoVar <- tclVar("1")
 cantoBox <- tkcheckbutton(top, variable = cantoVar)
 
 
-	onOK <- function() 
+	onOK <- function()
 	{
 	#closeDialog()
    tmax <- round(as.numeric(tclvalue(tmaxVar)))
-        if (is.na(tmax) || tmax <= 0) 
+        if (is.na(tmax) || tmax <= 0)
         {
         errorCondition(message = "Number of simulations must be a positive integer")
         return()
         }
   	cl <- round(as.numeric(tclvalue(clVar)))
-        if (is.na(cl) || cl <= 0) 
+        if (is.na(cl) || cl <= 0)
         {
         errorCondition(message = "Number of columns on the simulated arena must be a positive integer.")
         return()
         }
-	ln <- round(as.numeric(tclvalue(lnVar)))
-        if (is.na(ln) || ln <= 0) 
+	rw <- round(as.numeric(tclvalue(rwVar)))
+        if (is.na(rw) || rw <= 0)
         {
-        errorCondition("Number of lines on the simulated arena must be a positive integer.")
+        errorCondition("Number of rows on the simulated arena must be a positive integer.")
         return()
         }
    i1 <- as.numeric(tclvalue(i1Var))
-        if (i1<0 || i1 > 100) 
+        if (i1<0 || i1 > 100)
         {
         errorCondition(message = "Colonization constant must be between 0 and 10")
         return()
         }
    i2 <- as.numeric(tclvalue(i2Var))
-        if (i2<0 || i2 > 100) 
+        if (i2<0 || i2 > 100)
         {
         errorCondition(message = "Colonization constant must be between 0 and 10")
         return()
         }
-   fi1 <- as.numeric(tclvalue(fi1Var))
-   fi2 <- as.numeric(tclvalue(fi2Var))
+   f01 <- as.numeric(tclvalue(f01Var))
+   f02 <- as.numeric(tclvalue(f02Var))
    pe <- as.numeric(tclvalue(peVar))
    distr <- as.numeric(tclvalue(distrVar))
    cantoVF <- as.logical(as.numeric(tclvalue(cantoVar)))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
-        if (dsnameValue == "Do_Not_Save" | dsnameValue=="") 
+        if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
-        	command <- paste("metaComp(tmax = ",tmax, ", cl = ", cl,", fi1 = ", fi1,", fi2 = ", fi2,", rw =", ln,", i1 = ", i1,", i2 = ", i2,", pe = ", pe,", D = ", distr,", anima = ", cantoVF, ")", sep = "")
+        	command <- paste("metaComp(tmax = ",tmax, ", cl = ", cl,", f01 = ", f01,", f02 = ", f02,", rw =", rw,", i1 = ", i1,", i2 = ", i2,", pe = ", pe,", D = ", distr,", anima = ", cantoVF, ")", sep = "")
         }
-        else  
+        else
 		  {
-		  command <- paste(dsnameValue,"<- metaComp(tmax = ",tmax, ", cl = ", cl,", fi1 = ", fi1,", fi2 = ", fi2,", rw =", ln,", i1 = ", i1,", i2 = ", i2,", pe = ", pe,", D = ", distr,", anima = ", cantoVF, ")", sep = "")
+		  command <- paste(dsnameValue,"<- metaComp(tmax = ",tmax, ", cl = ", cl,", f01 = ", f01,", f02 = ", f02,", rw =", rw,", i1 = ", i1,", i2 = ", i2,", pe = ", pe,", D = ", distr,", anima = ", cantoVF, ")", sep = "")
 		  }
 ########
-#metaComp(tmax=100,cl=100,ln=100,fi1=0.1,fi2=0.4,i1=0.4,i2=0.5,pe=0.25)
+
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
 	}
@@ -445,13 +445,13 @@ tkgrid(tklabel(top, text="Enter name for data set:"), entryDsname, sticky="e")
 tkgrid(tklabel(top, text="Simulation Arena Conditions :", fg="blue"), sticky="w")
 tkgrid(tklabel(top, text = "Maximum time"), tmaxEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Columns"), clEntry, sticky = "e")
-tkgrid(tklabel(top, text = "Rows"), lnEntry, sticky = "e")
+tkgrid(tklabel(top, text = "Rows"), rwEntry, sticky = "e")
 #
 tkgrid(tklabel(top, text="Best Competitor Species :", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text="Initial occupancy "), fi1VarSlider, sticky="se")
+tkgrid(tklabel(top, text="Initial occupancy "), f01VarSlider, sticky="se")
 tkgrid(tklabel(top, text = "Colonization coefficient "), i1Entry, sticky = "e")
 tkgrid(tklabel(top, text="Inferior Competitor Species :", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text="Initial occupancy "), fi2VarSlider, sticky="se")
+tkgrid(tklabel(top, text="Initial occupancy "), f02VarSlider, sticky="se")
 tkgrid(tklabel(top, text = "Colonization coefficient  "), i2Entry, sticky = "e")
 tkgrid(tklabel(top, text="Both Species :", fg="blue"), sticky="w")
 tkgrid(tklabel(top, text = "Prob. Extinction  "), peEntry, sticky = "se")
@@ -462,10 +462,10 @@ tkgrid(buttonsFrame, sticky = "w", columnspan = 2)
 tkgrid.configure(entryDsname, sticky = "w")
 tkgrid.configure(tmaxEntry, sticky = "w")
 tkgrid.configure(clEntry, sticky = "w")
-tkgrid.configure(lnEntry, sticky = "w")
-tkgrid.configure(fi1VarSlider, sticky = "w")
+tkgrid.configure(rwEntry, sticky = "w")
+tkgrid.configure(f01VarSlider, sticky = "w")
 tkgrid.configure(i1Entry, sticky = "w")
-tkgrid.configure(fi2VarSlider, sticky = "w")
+tkgrid.configure(f02VarSlider, sticky = "w")
 tkgrid.configure(i2Entry, sticky = "w")
 tkgrid.configure(peEntry, sticky = "w")
 tkgrid.configure(distrEntry, sticky = "w")

--- a/R/EcoVirtual.MetaMenu.R
+++ b/R/EcoVirtual.MetaMenu.R
@@ -14,8 +14,8 @@ lnVar <- tclVar("20")
 clEntry <- tkentry(top, width = "4", textvariable = clVar)
 lnEntry <- tkentry(top, width = "4", textvariable = lnVar)
 ### controle de barra
-fiVar <- tclVar(0.4)
-fiVarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fiVar, resolution=0.01, orient="horizontal")
+f0Var <- tclVar(0.4)
+f0VarSlider <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f0Var, resolution=0.01, orient="horizontal")
 #####
 iVar <- tclVar("0.1") ## nclassVar ->iVar
 iEntry <- tkentry(top, width = "6", textvariable = iVar)
@@ -48,17 +48,17 @@ peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution
         errorCondition(message = "Colonization constant must be between 0 and 10")
         return()
         }
-   fi <- as.numeric(tclvalue(fiVar))
+   f0 <- as.numeric(tclvalue(f0Var))
    pe <- as.numeric(tclvalue(peVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
         if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
-        	command <- paste("metaCi(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
+        	command <- paste("metaCi(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
         }
         else
 		  {
-		  command <- paste(dsnameValue,"<- metaCi(tmax = ",tf, ", rw = ", cl,", fi = ", fi,", ln =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
+		  command <- paste(dsnameValue,"<- metaCi(tmax = ",tf, ", rw = ", cl,", f0 = ", f0,", ln =", ln,", ci = ", i,", pe = ", pe, ")", sep = "")
 		  }
 ########
 	doItAndPrint(command)
@@ -73,7 +73,7 @@ tkgrid(tklabel(top, text = "Columns  "), clEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Rows  "), lnEntry, sticky = "e")
 #
 tkgrid(tklabel(top, text="Species parameters :", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text="Initial occupancy  "), fiVarSlider, sticky="se")
+tkgrid(tklabel(top, text="Initial occupancy  "), f0VarSlider, sticky="se")
 tkgrid(tklabel(top, text = "Colonization coefficient  "), iEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Prob. Extinction  "), peEntry, sticky = "se")
 tkgrid(buttonsFrame, sticky = "w", columnspan = 2)
@@ -81,7 +81,7 @@ tkgrid.configure(entryDsname, sticky = "w")
 tkgrid.configure(tfEntry, sticky = "w")
 tkgrid.configure(clEntry, sticky = "w")
 tkgrid.configure(lnEntry, sticky = "w")
-tkgrid.configure(fiVarSlider, sticky = "w")
+tkgrid.configure(f0VarSlider, sticky = "w")
 tkgrid.configure(iEntry, sticky = "w")
 tkgrid.configure(peEntry, sticky = "w")
 dialogSuffix(rows = 8, columns = 2, focus = tfEntry)
@@ -103,11 +103,11 @@ clVar <- tclVar("20")
 lnVar <- tclVar("20")
 clEntry <- tkentry(top, width = "4", textvariable = clVar)
 lnEntry <- tkentry(top, width = "4", textvariable = lnVar)
-fiVar <- tclVar(0.25) ## nclassVar ->fiVar
-fiEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fiVar, resolution=0.01, orient="horizontal")
-pcVar <- tclVar("0.1") ## nclassVar ->fiVar
-pcEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=pcVar, resolution=0.01, orient="horizontal")
-peVar <- tclVar("0.05") ## nclassVar ->fiVar
+f0Var <- tclVar(0.25) ## nclassVar ->f0Var
+f0Entry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f0Var, resolution=0.01, orient="horizontal")
+piVar <- tclVar("0.1") ## nclassVar ->f0Var
+piEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=piVar, resolution=0.01, orient="horizontal")
+peVar <- tclVar("0.05") ## nclassVar ->f0Var
 peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution=0.01, orient="horizontal")
 	onOK <- function()
 	{
@@ -130,21 +130,21 @@ peEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=peVar, resolution
             errorCondition("Number of lines on the simulated arena must be a positive integer.")
             return()
         }
-        fi <- as.numeric(tclvalue(fiVar))
-        pc <- as.numeric(tclvalue(pcVar))
+        f0 <- as.numeric(tclvalue(f0Var))
+        pi <- as.numeric(tclvalue(piVar))
         pe <- as.numeric(tclvalue(peVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
         if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
-        	command <- paste("metaPop(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", pe = ", pe, ")", sep = "")
+        	command <- paste("metaPop(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", pi = ", pi,", pe = ", pe, ")", sep = "")
         }
         else
 		  {
-		  command <- paste(dsnameValue,"<-metaPop(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", pe = ", pe, ")", sep = "")
+		  command <- paste(dsnameValue,"<-metaPop(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", pi = ", pi,", pe = ", pe, ")", sep = "")
 		  }
 ########
-#	command <- paste("metaPop(tf = ",tf, ", cl = ", cl,", fi = ", fi,", ln =", ln,", pc = ", pc,", pe = ", pe, ")", sep = "")
+#	command <- paste("metaPop(tf = ",tf, ", cl = ", cl,", f0 = ", f0,", ln =", ln,", pi = ", pi,", pe = ", pe, ")", sep = "")
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
 	}
@@ -155,23 +155,23 @@ tkgrid(tklabel(top, text = "Maximum time  "), tfEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Columns  "), clEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Rows  "), lnEntry, sticky = "e")
 tkgrid(tklabel(top, text="Species parameters : ", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text = "Initial occupancy  "), fiEntry, sticky = "se")
-tkgrid(tklabel(top, text = "Colonization probability "), pcEntry, sticky = "se")
+tkgrid(tklabel(top, text = "Initial occupancy  "), f0Entry, sticky = "se")
+tkgrid(tklabel(top, text = "Colonization probability "), piEntry, sticky = "se")
 tkgrid(tklabel(top, text = "Extinction probability "), peEntry, sticky = "se")
 tkgrid(buttonsFrame, sticky = "w", columnspan = 2)
 tkgrid.configure(entryDsname, sticky = "w")
 tkgrid.configure(tfEntry, sticky = "w")
 tkgrid.configure(clEntry, sticky = "w")
 tkgrid.configure(lnEntry, sticky = "w")
-tkgrid.configure(fiEntry, sticky = "w")
-tkgrid.configure(pcEntry, sticky = "w")
+tkgrid.configure(f0Entry, sticky = "w")
+tkgrid.configure(piEntry, sticky = "w")
 tkgrid.configure(peEntry, sticky = "w")
 dialogSuffix(rows = 7, columns = 2, focus = tfEntry)
 }
 ###############################################################
 ##################################################
-#metaCiEr <-function(tf,cl,ln,fi,i,e)
-#metaEr <-function(tf,cl,ln,fi,pc,e)
+#metaCiEr <-function(tf,cl,ln,f0,i,e)
+#metaEr <-function(tf,cl,ln,f0,pi,e)
 resEff <-function ()
 {
 initializeDialog(title = gettextRcmdr("Rescue Effect"))
@@ -185,11 +185,11 @@ clVar <- tclVar("20")
 lnVar <- tclVar("20")
 clEntry <- tkentry(top, width = "4", textvariable = clVar)
 lnEntry <- tkentry(top, width = "4", textvariable = lnVar)
-fiVar <- tclVar(0.25) ## nclassVar ->fiVar
-fiEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fiVar, resolution=0.01, orient="horizontal")
-pcVar <- tclVar("0.1") ## nclassVar ->fiVar
-pcEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=pcVar, resolution=0.01, orient="horizontal")
-eVar <- tclVar("0.05") ## nclassVar ->fiVar
+f0Var <- tclVar(0.25) ## nclassVar ->f0Var
+f0Entry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f0Var, resolution=0.01, orient="horizontal")
+piVar <- tclVar("0.1") ## nclassVar ->f0Var
+piEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=piVar, resolution=0.01, orient="horizontal")
+eVar <- tclVar("0.05") ## nclassVar ->f0Var
 eEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable = eVar, resolution=0.01, orient="horizontal")
 	onOK <- function()
 	{
@@ -218,20 +218,20 @@ eEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable = eVar, resolution
             errorCondition(message = "Extinction constant must be between 0 and 1")
             return()
         }
-        fi <- as.numeric(tclvalue(fiVar))
-        pc <- as.numeric(tclvalue(pcVar))
+        f0 <- as.numeric(tclvalue(f0Var))
+        pi <- as.numeric(tclvalue(piVar))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
         if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
-        	command <- paste("metaEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", ce = ", e, ")", sep = "")
+        	command <- paste("metaEr(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", pi = ", pi,", ce = ", e, ")", sep = "")
         }
         else
 		  {
-		  command <- paste(dsnameValue,"<-metaEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", pc = ", pc,", ce = ", e, ")", sep = "")
+		  command <- paste(dsnameValue,"<-metaEr(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", pi = ", pi,", ce = ", e, ")", sep = "")
 		  }
 ########
-#	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", fi = ", fi,", ln =", ln,", pc = ", pc,", e = ", e, ")", sep = "")
+#	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", f0 = ", f0,", ln =", ln,", pi = ", pi,", e = ", e, ")", sep = "")
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
 	}
@@ -242,22 +242,22 @@ tkgrid(tklabel(top, text = "Maximum time  "), tfEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Columns  "), clEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Rows  "), lnEntry, sticky = "e")
 tkgrid(tklabel(top, text="Species parameters : ", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text = "Initial occupancy "), fiEntry, sticky = "e")
-tkgrid(tklabel(top, text = "Colonization probability  "), pcEntry, sticky = "e")
+tkgrid(tklabel(top, text = "Initial occupancy "), f0Entry, sticky = "e")
+tkgrid(tklabel(top, text = "Colonization probability  "), piEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Extinction coefficient  "), eEntry, sticky = "e")
 tkgrid(buttonsFrame, sticky = "w", columnspan = 2)
 tkgrid.configure(entryDsname, sticky = "w")
 tkgrid.configure(tfEntry, sticky = "w")
 tkgrid.configure(clEntry, sticky = "w")
 tkgrid.configure(lnEntry, sticky = "w")
-tkgrid.configure(fiEntry, sticky = "w")
-tkgrid.configure(pcEntry, sticky = "w")
+tkgrid.configure(f0Entry, sticky = "w")
+tkgrid.configure(piEntry, sticky = "w")
 tkgrid.configure(eEntry, sticky = "w")
 dialogSuffix(rows = 8, columns = 2, focus = tfEntry)
 }
 ################################################
-#metaCiEr <-function(tf,cl,ln,fi,i,e)
-#metaEr <-function(tf,cl,ln,fi,pc,e)
+#metaCiEr <-function(tf,cl,ln,f0,i,e)
+#metaEr <-function(tf,cl,ln,f0,pi,e)
 
 
 resEffcol <-function ()
@@ -273,11 +273,11 @@ clVar <- tclVar("20")
 lnVar <- tclVar("20")
 clEntry <- tkentry(top, width = "4", textvariable = clVar)
 lnEntry <- tkentry(top, width = "4", textvariable = lnVar)
-fiVar <- tclVar(0.25) ## nclassVar ->fiVar
-fiEntry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=fiVar, resolution=0.01, orient="horizontal")
-iVar <- tclVar("0.1") ## nclassVar ->fiVar
+f0Var <- tclVar(0.25) ## nclassVar ->f0Var
+f0Entry <- tkscale(top, from=0, to=1, showvalue=TRUE, variable=f0Var, resolution=0.01, orient="horizontal")
+iVar <- tclVar("0.1") ## nclassVar ->f0Var
 iEntry <- tkentry(top, width = "6", textvariable = iVar)
-eVar <- tclVar("0.05") ## nclassVar ->fiVar
+eVar <- tclVar("0.05") ## nclassVar ->f0Var
 eEntry <- tkentry(top, width = "6", textvariable = eVar)
 	onOK <- function()
 	{
@@ -312,19 +312,19 @@ eEntry <- tkentry(top, width = "6", textvariable = eVar)
             errorCondition(message = "Extinction constant must be positive")
             return()
         }
-        fi <- as.numeric(tclvalue(fiVar))
+        f0 <- as.numeric(tclvalue(f0Var))
 ############ Data name
    dsnameValue <- trim.blanks(tclvalue(dsname))
         if (dsnameValue == "Do_Not_Save" | dsnameValue=="")
         {
-        	command <- paste("metaCiEr(tmax = ",tf, ", cl = ", cl,", fi = ", fi,", rw =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
+        	command <- paste("metaCiEr(tmax = ",tf, ", cl = ", cl,", f0 = ", f0,", rw =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
         }
         else
 		  {
-		  command <- paste(dsnameValue,"<-metaCiEr(tmax = ",tf, ", rw = ", cl,", fi = ", fi,", ln =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
+		  command <- paste(dsnameValue,"<-metaCiEr(tmax = ",tf, ", rw = ", cl,", f0 = ", f0,", ln =", ln,", ci = ", i,", ce = ", e, ")", sep = "")
 		  }
 ########
-#	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", fi = ", fi,", ln =", ln,", pc = ", pc,", e = ", e, ")", sep = "")
+#	command <- paste("metaEr(tf = ",tf, ", cl = ", cl,", f0 = ", f0,", ln =", ln,", pi = ", pi,", e = ", e, ")", sep = "")
 	doItAndPrint(command)
 	tkfocus(CommanderWindow())
 	}
@@ -335,7 +335,7 @@ tkgrid(tklabel(top, text = "Maximum time  "), tfEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Columns  "), clEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Rows  "), lnEntry, sticky = "e")
 tkgrid(tklabel(top, text="Species parameters  :", fg="blue"), sticky="w")
-tkgrid(tklabel(top, text = "Initial occupancy  "), fiEntry, sticky = "e")
+tkgrid(tklabel(top, text = "Initial occupancy  "), f0Entry, sticky = "e")
 tkgrid(tklabel(top, text = "Colonization coefficient  "), iEntry, sticky = "e")
 tkgrid(tklabel(top, text = "Extinction coefficient  "), eEntry, sticky = "e")
 tkgrid(buttonsFrame, sticky = "w", columnspan = 2)
@@ -343,7 +343,7 @@ tkgrid.configure(entryDsname, sticky = "w")
 tkgrid.configure(tfEntry, sticky = "w")
 tkgrid.configure(clEntry, sticky = "w")
 tkgrid.configure(lnEntry, sticky = "w")
-tkgrid.configure(fiEntry, sticky = "w")
+tkgrid.configure(f0Entry, sticky = "w")
 tkgrid.configure(iEntry, sticky = "w")
 tkgrid.configure(eEntry, sticky = "w")
 dialogSuffix(rows = 8, columns = 2, focus = tfEntry)


### PR DESCRIPTION
commit: menu metaComp argumentos:
para deixar os argumentos da função metaComp de acordo com as mudanças
feitas no pacote EcoVirtual.
ln -> rw
fi1 -> f01
fi2 -> f02

commit: nomes argumentos funções metapops …
para se adequar às mudanças feitas no pacote EcoVirtual:
mudei os nomes dos argumentos das funções de metapopulações (metaPop,
metaCi, metaEr, metaCiEr) para ter consistência com os roteiros e com a
função de coexistência em metapopulações (metaComp).
fi -> f0
pc -> pi
